### PR TITLE
Make QuerySet for FolderAdminForm.parent lazy to prevent database errors

### DIFF
--- a/django_folders/forms.py
+++ b/django_folders/forms.py
@@ -5,8 +5,12 @@ from .models import Folder
 
 
 class FolderAdminForm(forms.ModelForm):
-    parent = FolderModelChoiceField(queryset=Folder.objects.all(), required=False,
+    parent = FolderModelChoiceField(queryset=Folder.objects.none(), required=False,
                                     label="Elternordner")
+
+    def __init__(self, *args, **kwargs):
+        super(FolderAdminForm, self).__init__(*args, **kwargs)
+        self.fields['parent'].queryset = Folder.objects.all()
 
     class Meta:
         model = Folder

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="django-folders",
     author="Jonas und der Wolf GmbH",
     author_email="info@jonasundderwolf.de",
-    version='0.1',
+    version='0.2',
     packages=find_packages(),
     install_requires=['django-spurl'],
     include_package_data=True,


### PR DESCRIPTION
This should fix database errors when running tests starting with an empty db.